### PR TITLE
Update exclude special characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ override.tf.json
 # Ansible
 *.pub
 *.ppk
+
+# Infracost
+.infracost

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cross_account_ids"></a> [cross\_account\_ids](#input\_cross\_account\_ids) | A list of strings containing the account IDs of AWS accounts that should have cross-account access to this secret | `list(string)` | `[]` | no |
 | <a name="input_empty_value"></a> [empty\_value](#input\_empty\_value) | Whether the secret should be generated without a value | `bool` | `false` | no |
-| <a name="input_exclude_characters"></a> [exclude\_characters](#input\_exclude\_characters) | String of the characters that you don't want in the password | `string` | `"\" # $ % & ' ( ) * + , - . / : ; < = > ? [ \\ ] ^ ` { \| } ~" | no |
+| <a name="input_exclude_characters"></a> [exclude\_characters](#input\_exclude\_characters) | String of the characters that you don't want in the password | `string` | `"\" # $ % & ' ( ) * + , . / : ; < = > ? @ [ \\ ] ^ ` { \| } ~" | no |
 | <a name="input_exclude_lowercase"></a> [exclude\_lowercase](#input\_exclude\_lowercase) | Specifies whether to exclude lowercase letters from the password | `bool` | `false` | no |
 | <a name="input_exclude_numbers"></a> [exclude\_numbers](#input\_exclude\_numbers) | Specifies whether to exclude numbers from the password | `bool` | `false` | no |
 | <a name="input_exclude_punctuation"></a> [exclude\_punctuation](#input\_exclude\_punctuation) | Specifies whether to exclude punctuation characters from the password: ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ \_ ` { | } ~` | `bool` | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -80,7 +80,7 @@ variable "replicas" {
 variable "exclude_characters" {
   description = "String of the characters that you don't want in the password"
   type        = string
-  default     = "\" # $ % & ' ( ) * + , . / : ; < = > ? @ [ \ ] ^ ` { | } ~"
+  default     = "\" # $ % & ' ( ) * + , . / : ; < = > ? @ [ \\ ] ^ ` { | } ~"
   # Permitted characters are: ! _ -
   # The defaults are intended to be generally safe for use in various RDS database types, Linux, and Windows.
 }

--- a/variables.tf
+++ b/variables.tf
@@ -80,7 +80,9 @@ variable "replicas" {
 variable "exclude_characters" {
   description = "String of the characters that you don't want in the password"
   type        = string
-  default     = "\" # $ % & ' ( ) * + , - . / : ; < = > ? [ \\ ] ^ ` { | } ~" # Include some punctuations, but avoid ones known to break database passwords
+  default     = "\" # $ % & ' ( ) * + , . / : ; < = > ? @ [ \ ] ^ ` { | } ~"
+  # Permitted characters are: ! _ -
+  # The defaults are intended to be generally safe for use in various RDS database types, Linux, and Windows.
 }
 
 variable "exclude_lowercase" {


### PR DESCRIPTION
Updated the "exclude_characters" default value to:
"\" # $ % & ' ( ) * + , . / : ; < = > ? @ [ \\ ] ^ ` { | } ~"

This effectively changes the special characters used from:
! @ _ 

to:
! _ -

An "@" in a password caused RDS Postgres DB creation to fail.

https://github.com/awsdocs/aws-cloudformation-user-guide/blob/c03a45977c5a506e09a22dbe05ff980bec79b805/doc_source/aws-properties-rds-database-instance.md#cfn-rds-dbinstance-masteruserpassword

Unsure why this wasn't a problem before.